### PR TITLE
fix: close lsif file after writing

### DIFF
--- a/parser/api.go
+++ b/parser/api.go
@@ -66,9 +66,17 @@ func FromScipFile(scipFile string, srcDir string) (*object.SourceContext, error)
 	// still save this file for debug
 	lsifFile := filepath.Join(srcDir, "dump.lsif")
 	lsifWriter, err := os.OpenFile(lsifFile, os.O_WRONLY|os.O_CREATE, 0o666)
-	defer lsifWriter.Close()
+	if err != nil {
+		return nil, err
+	}
 
 	err = scip.WriteNDJSON(scip.ElementsToJsonElements(lsifIndex), lsifWriter)
+	if err != nil {
+		_ = lsifWriter.Close()
+		return nil, err
+	}
+
+	err = lsifWriter.Close()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The `dump.lsif` contained malformed JSON output, for example:

```
{"id":139,"type":"vertex","label":"range","start":{"line":4,"character":11},"end":{"line":4,"character":18}}
{"id":140,"type":"edge","label":"next","inV":39,"outV":139}
{"id":141,"type":"edge","label":"item","inVs":[139],"outV":40,"document":124,"property":"references"}
{"id":142,"type":"edge","label":"contains","inVs":[125,129,132,135,139],"outV":124}
"line":4,"character":18}}
{"id":143,"type":"edge","label":"next","inV":39,"outV":142}
```

This in turn caused warnings and sometimes crashes:

```
WARN[0000] invalid json format: V":124}
```

```
WARN[0000] invalid json format: "line":4,"character":18}}
panic: EOF

goroutine 1 [running]:
main.panicIfErr(...)
        /home/pah/ocxmr-repos/opt/srctx/cmd/srctx/main.go:31
main.mainFunc({0xc0000360a0, 0xa, 0xa})
        /home/pah/ocxmr-repos/opt/srctx/cmd/srctx/main.go:26 +0x145
main.main()
        /home/pah/ocxmr-repos/opt/srctx/cmd/srctx/main.go:13 +0x2e
```

This hopefully fixes the bug, it does in my limited testing.